### PR TITLE
Update pin-project dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 futures = "0.3.1"
-pin-project = "0.4.6"
+pin-project = "1.0.10"
 static_assertions = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes #2

To help verify that this change is okay, I patched Substrate's commit [7cb0e76](https://github.com/paritytech/substrate/commit/7cb0e76b847a49e2a9227e0c039bcbb335c83309) to use this version of rw-stream-sink, and ran `cargo test` on the following crates (the ones that use libp2p, AFICT):
* sc-peerset
* sc-authority-discovery
* sc-telemetry
* sc-consensus
* sc-cli
* sc-network-gossip
* sc-network-test
* sc-network

In all cases, the tests passed.